### PR TITLE
Dump shaders

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -33,6 +33,21 @@ do
 		DUMPER_EXIT_CODE=$?
 	fi
 done <   <(find . -type f -name "pak01_dir.vpk" -print0)
+
+while IFS= read -r -d '' file
+do
+	echo " $file"
+
+	"$VRF_PATH" \
+		--input "$file" \
+		--output "$(echo "$file" | sed -e 's/\.vpk$/\//g')" \
+		--vpk_cache \
+		--vpk_decompile \
+		--vpk_extensions "vcs"
+	if [[ "$DUMPER_EXIT_CODE" -eq 0 ]] && [[ $? -ne 0 ]]; then
+		DUMPER_EXIT_CODE=$?
+	fi
+done <   <(find . -type f -name "shaders_vulkan_dir.vpk" -print0)
 set -e
 
 echo "::endgroup::"

--- a/update.sh
+++ b/update.sh
@@ -48,6 +48,15 @@ do
 		DUMPER_EXIT_CODE=$?
 	fi
 done <   <(find . -type f -name "shaders_vulkan_dir.vpk" -print0)
+
+while IFS= read -r -d '' file
+do
+	newfile=$(echo "$file" | sed -e 's/_vulkan_[0-9]\+\.vfx$/.slang/g')
+	if [[ "$file" != "$newfile" ]]; then
+		mv "$file" "$newfile"
+	fi
+done <   <(find . -type f -name "*_vulkan_*.vfx" -print0)
+
 set -e
 
 echo "::endgroup::"


### PR DESCRIPTION
Dump vfx metadata and spirv cross output of the first shader variant in a single `slang` file.

Adds 150k lines, see the initial dump [here](https://github.com/kristiker/GameTracking-CS2/commit/43f29bb18be5acf8b192d77e818675b1a47e9cd6).

Example [diff](https://github.com/kristiker/GameTracking-CS2/commit/52ded5467b65b6b9ddddd7f8c76f556863a40891):
<img width="1213" height="762" alt="image" src="https://github.com/user-attachments/assets/f01032cf-96f1-40f8-bf26-735bbb3828a8" />
